### PR TITLE
Updated the node tests to account for the recent changes

### DIFF
--- a/test-node/fixture/blockinjection_test_file_instrumented.js
+++ b/test-node/fixture/blockinjection_test_file_instrumented.js
@@ -1,17 +1,17 @@
-_$jscoverage['blockinjection_test_file.js'][0]++;
+_$jscoverage['blockinjection_test_file.js'][1]++;
 if(true)
   {
-_$jscoverage['blockinjection_test_file.js'][1]++;
+_$jscoverage['blockinjection_test_file.js'][2]++;
 var a=true;}
 
 else {
-_$jscoverage['blockinjection_test_file.js'][2]++;
+_$jscoverage['blockinjection_test_file.js'][3]++;
 if(false)
   {
-_$jscoverage['blockinjection_test_file.js'][3]++;
+_$jscoverage['blockinjection_test_file.js'][4]++;
 if (true)
     {
-_$jscoverage['blockinjection_test_file.js'][4]++;
+_$jscoverage['blockinjection_test_file.js'][5]++;
 var b=false;}
 }
 }

--- a/test-node/fixture/simple_test_file_instrumented.js
+++ b/test-node/fixture/simple_test_file_instrumented.js
@@ -1,14 +1,14 @@
-_$jscoverage['simple_test_file.js'][0]++;
-//this is test source
 _$jscoverage['simple_test_file.js'][1]++;
-var test='1234';
+//this is test source
 _$jscoverage['simple_test_file.js'][2]++;
+var test='1234';
+_$jscoverage['simple_test_file.js'][3]++;
 if (test === '1234')
   {
-_$jscoverage['simple_test_file.js'][3]++;
+_$jscoverage['simple_test_file.js'][4]++;
 console.log(true);}
 
-_$jscoverage['simple_test_file.js'][4]++;
-//comment
 _$jscoverage['simple_test_file.js'][5]++;
+//comment
+_$jscoverage['simple_test_file.js'][6]++;
 console.log(test);

--- a/test-node/fixture/simple_test_file_instrumented_full.js
+++ b/test-node/fixture/simple_test_file_instrumented_full.js
@@ -12,17 +12,17 @@ _$jscoverage['simple_test_file.js'][3]=0;
 _$jscoverage['simple_test_file.js'][4]=0;
 _$jscoverage['simple_test_file.js'][5]=0;
 _$jscoverage['simple_test_file.js'][6]=0;
-}_$jscoverage['simple_test_file.js'][0]++;
+}_$jscoverage['simple_test_file.js'][1]++;
 //this is test source
-_$jscoverage['simple_test_file.js'][1]++;
-var test='1234';
 _$jscoverage['simple_test_file.js'][2]++;
+var test='1234';
+_$jscoverage['simple_test_file.js'][3]++;
 if (test === '1234')
   {
-_$jscoverage['simple_test_file.js'][3]++;
+_$jscoverage['simple_test_file.js'][4]++;
 console.log(true);}
 
-_$jscoverage['simple_test_file.js'][4]++;
-//comment
 _$jscoverage['simple_test_file.js'][5]++;
+//comment
+_$jscoverage['simple_test_file.js'][6]++;
 console.log(test);

--- a/test-node/tests/blanket_core.js
+++ b/test-node/tests/blanket_core.js
@@ -5,6 +5,17 @@ var assert = require("assert"),
     falafel = require("../../lib/falafel").falafel,
     core_fixtures = require("../fixture/core_fixtures");
 
+function normalizeWhitespace(str) {
+    return str
+        .replace(/\r\n/g, '\n')
+        .replace(/\r/g, '\n')
+        .replace(/\s+\n/g, '\n')
+        .replace(/\n\s+/g, '\n');
+}
+function assertString(actual, expected) {
+    assert.equal(normalizeWhitespace(actual), normalizeWhitespace(expected));
+}
+
 describe('tracking', function(){
     
     describe('tracking setup', function(){
@@ -26,7 +37,7 @@ describe('tracking', function(){
                 ];
 
             var result = blanketCore._trackingSetup(filename,sourceArray);
-            assert.equal(result,expectedSource);
+            assertString(result,expectedSource);
         });
     });
     describe('source setup', function(){
@@ -43,7 +54,7 @@ describe('tracking', function(){
                 ];
 
             var result = blanketCore._prepareSource(source);
-            assert.equal(result.toString(),expectedSource.toString());
+            assertString(result.toString(),expectedSource.toString());
         });
     });
     describe('add tracking', function(){
@@ -53,7 +64,7 @@ describe('tracking', function(){
                   core_fixtures.simple_test_file_js,
                   {loc:true,comment:true},
                   blanketCore._addTracking,"simple_test_file.js" );
-            assert.equal(result.toString(),
+            assertString(result.toString(),
                 core_fixtures.simple_test_file_instrumented_js);
             
         });
@@ -67,13 +78,11 @@ describe('tracking', function(){
                   {loc:true,comment:true},
                   blanketCore._addTracking,"blockinjection_test_file.js" );
             
-            assert.equal(result.toString(),
+            assertString(result.toString(),
                 core_fixtures.blockinjection_test_file_instrumented_js);
-            
         });
     });
 });
-
 
 describe('blanket instrument', function(){
   describe('instrument file', function(){
@@ -82,7 +91,7 @@ describe('blanket instrument', function(){
           inputFile: core_fixtures.simple_test_file_js,
           inputFileName: "simple_test_file.js"
         },function(result){
-          assert.equal(result,
+          assertString(result,
             core_fixtures.simple_test_file_instrumented_full_js);
           done();
         });


### PR DESCRIPTION
Updated the test fixtures to start counting from 1.

Also, before comparing the expected and actual result strings, they are passed to a function that tries to normalize line endings and trims all lines (otherwise tests would not pass due to whitespace differences).
