### PR TITLE
Updated node part to handle default mocha behaviour.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
     "test": "grunt --verbose blanket-coverage",
     "travis-cov": {
       "threshold": 80
+    },
+    "blanket": {
+      "pattern": "test"
     }
   },
   "keywords": [

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,17 @@
   /*-------------------------------*/
 
 module.exports = function(pattern){
+    if (!pattern){
+        var fs = require("fs");
+        var path = process.cwd() + '/package.json';
+        var file = JSON.parse(fs.readFileSync(path, 'utf8'));
+        var packageConfig = file.scripts &&
+                            file.scripts.blanket &&
+                            file.scripts.blanket.pattern ?
+                              file.scripts.blanket.pattern :
+                              "src";
+        pattern = packageConfig;
+    }
     require("./blanket");
     require("./node")(pattern);
 };


### PR DESCRIPTION
Can now be run on a directory using `mocha --require blanket` and the pattern will be taken from the package.json (under scripts.blanket.pattern) or will default to `src`.
