### PR TITLE
More changes to node get/set filter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,20 +8,25 @@
   /*                                */
   /*-------------------------------*/
 
-module.exports = function(pattern){
-    if (!pattern){
-        var fs = require("fs");
-        var path = process.cwd() + '/package.json';
-        var file = JSON.parse(fs.readFileSync(path, 'utf8'));
-        var packageConfig = file.scripts &&
-                            file.scripts.blanket &&
-                            file.scripts.blanket.pattern ?
-                              file.scripts.blanket.pattern :
-                              "src";
-        pattern = packageConfig;
-    }
-    require("./blanket");
-    require("./node")(pattern);
-};
+
+var fs = require("fs");
+var path = process.cwd() + '/package.json';
+
+var file = JSON.parse(fs.readFileSync(path, 'utf8'));
+
+var packageConfig = file.scripts &&
+                    file.scripts.blanket &&
+                    file.scripts.blanket.pattern ?
+                      file.scripts.blanket.pattern :
+                      "src";
+pattern = packageConfig;
+
+var blanket = require("./blanket").blanket;
+blanket.setFilter(pattern);
+require("./node");
+
+
+module.exports = blanket;
+
 
 

--- a/src/node.js
+++ b/src/node.js
@@ -5,21 +5,21 @@ function normalizeBackslashes(str) {
 }
 
 //not completed, still needs a lot of work.
-module.exports = function(subdir){
+module.exports = function(){
     var fs = require("fs");
     var oldLoader = require.extensions['.js'];
     var path = require("path");
 
     //you can pass in a string, a regex, or an array of files
-    function matchPattern(filename){
-        if (typeof subdir === 'string'){
-            return filename.indexOf(normalizeBackslashes(subdir)) > -1;
-        }else if ( subdir instanceof Array ){
-            return subdir.some(function(elem){
+    function matchPattern(filename,pattern){
+        if (typeof pattern === 'string'){
+            return filename.indexOf(normalizeBackslashes(pattern)) > -1;
+        }else if ( pattern instanceof Array ){
+            return pattern.some(function(elem){
                 return filename.indexOf(normalizeBackslashes(elem)) > -1;
             });
-        }else if (subdir instanceof RegExp){
-            return subdir.test(filename);
+        }else if (pattern instanceof RegExp){
+            return pattern.test(filename);
         }else{
             throw new Error("Bad file instrument indicator.  Must be a string, regex, or array.");
         }
@@ -27,8 +27,10 @@ module.exports = function(subdir){
 
     //find current scripts
     require.extensions['.js'] = function(localModule, filename) {
+        var pattern = blanket.getFilter();
+    
         filename = normalizeBackslashes(filename);
-        if (matchPattern(filename)){
+        if (matchPattern(filename,pattern)){
             var content = fs.readFileSync(filename, 'utf8');
             blanket.instrument({
                 inputFile: content,
@@ -47,4 +49,4 @@ module.exports = function(subdir){
             oldLoader(localModule,filename);
         }
     };
-};
+}();

--- a/test-node/testrunner.js
+++ b/test-node/testrunner.js
@@ -1,5 +1,6 @@
 var path = require("path");
-require("../src/index")("/src/blanket");
+var blanket = require("../src/index");
+blanket.setFilter("/src/blanket");
 
 /*
 since we're using blanket to test blanket,


### PR DESCRIPTION
#118 doesn't actually handle all cases, so I refactored how it works.

Now with node you can use one of 3 methods to specify the pattern:
1. `require("blanket")` will default to `src`
2. `var blanket = require("blanket"); blanket.setFilter("test");` will set it to `test`
3. `require("blanket")` with an entry in your package.json under `scripts.blanket.pattern` will result in that value being used as the filter.
