### PR TITLE
Ensuring function name stays correct even after minification

### DIFF
--- a/src/qunit/reporter.js
+++ b/src/qunit/reporter.js
@@ -20,7 +20,7 @@ blanket.defaultReporter = function(coverage){
 
     var script = document.createElement("script");
     script.type = "text/javascript";
-    script.text = blanket_toggleSource.toString();
+    script.text = blanket_toggleSource.toString().replace('function ' + blanket_toggleSource.name, 'function blanket_toggleSource');
     body.appendChild(script);
 
     var percentage = function(number, total) {


### PR DESCRIPTION
After minification the function name will be changed but is still being referenced in the HTML as it's un-minified function name.
