### PR TITLE
Jasmine/RequireJS compatibility

### DIFF
--- a/src/adapters/jasmine-blanket.js
+++ b/src/adapters/jasmine-blanket.js
@@ -73,10 +73,30 @@
     }else{
         jasmine.getEnv().addReporter(new jasmine.BlanketReporter());
     }
+
+    //override existing jasmine execute
+    jasmine.getEnv().execute = function(){ console.log("waiting for blanket..."); };
+    
+    //check to make sure requirejs is completed before we start the test runner
+    var allLoaded = function() {
+        if (!_blanket.options("existingRequireJS")){
+            return true;
+        }else{
+            return window.jasmine.getEnv().currentRunner().specs().length > 0 && _blanket.outstandingRequireFiles === 0;
+        }
+    };
+
     blanket.beforeStartTestRunner({
         callback:function(){
             jasmine.getEnv().addReporter(new jasmine.BlanketReporter());
-            window.jasmine.getEnv().currentRunner().execute();
+            var check = function() {
+                if (allLoaded()) {
+                    window.jasmine.getEnv().currentRunner().execute();
+                } else {
+                    setTimeout(check, 13);
+                }
+            };
+            check();
      }
     });
 })();

--- a/src/blanketRequire.js
+++ b/src/blanketRequire.js
@@ -1,5 +1,7 @@
 (function(_blanket){
-_blanket.extend({utils: {
+_blanket.extend({
+    outstandingRequireFiles:0,
+    utils: {
     normalizeBackslashes: function(str) {
         return str.replace(/\\/g, '/');
     },
@@ -62,10 +64,11 @@ _blanket.extend({utils: {
 });
 
 _blanket.utils.oldloader = requirejs.load;
-
+_blanket.outstandingRequireFiles=0;
 requirejs.load = function (context, moduleName, url) {
-
+    _blanket.outstandingRequireFiles++;
     requirejs.cget(url, function (content) {
+        _blanket.outstandingRequireFiles--;
         var match = _blanket.options("filter");
         if (_blanket.utils.matchPatternAttribute(url.replace(".js",""),match)){
             _blanket.instrument({


### PR DESCRIPTION
Jasmine tests start on window.load.  Safari and RequireJS fires the window.load event before RequireJS has finished loading all the files.  Thanks to @provegard for developing the idea of an oustanding file counter and a check in the jasmine adapter to ensure that requirejs is finished before starting the test runner.
