### PR TITLE
Mocha adapter prevent premature/duplicate running

### DIFF
--- a/src/adapters/jasmine-blanket.js
+++ b/src/adapters/jasmine-blanket.js
@@ -82,6 +82,6 @@
         callback:function(){
             jasmine.getEnv().addReporter(new jasmine.BlanketReporter());
             window.jasmine.getEnv().currentRunner().execute();
-     }
+            jasmine.getEnv().execute = jasmine.getEnv().currentRunner().execute;     }
     });
 })();

--- a/src/adapters/mocha-blanket.js
+++ b/src/adapters/mocha-blanket.js
@@ -55,6 +55,9 @@
     var oldRun = mocha.run;
     mocha.run = function(){ console.log("waiting for blanket..."); };
     blanket.beforeStartTestRunner({
-        callback: oldRun
+        callback: function(){
+            oldRun();
+            mocha.run = oldRun;
+        }
     });
 })();


### PR DESCRIPTION
we override the mocha.run command until the files are instrumented then we run it manually and return the function reference to normal.
