### PR TITLE
Updating the dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
     "node": "0.8.*"
   },
   "dependencies": {
-    "coffee-script": "1.4.0"
   },
   "devDependencies": {
+    "coffee-script": "1.4.0",
     "mocha": "1.7.4",
     "travis-cov": "*",
     "grunt": "0.3.17"


### PR DESCRIPTION
Moving dev dependencies into the devDependencies section... this should prevent installing a lot of exra packages when using the published copy of blanket.
