### PR TITLE
Allow setting of regex pattern in package.json

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -72,7 +72,7 @@ require.extensions['.js'] = function(localModule, filename) {
 };
 
 //if a loader is specified, use it
-if (file.scripts.blanket.loader){
+if (file.scripts && file.scripts.blanket && file.scripts.blanket.loader){
     require(file.scripts.blanket.loader)(blanket);
 }
 


### PR DESCRIPTION
Allows using something like this in the package.json:

```
"blanket": { "regexPattern": "^((?!\/node_modules\/)(?!\/test\/).)*$" }
```

I think this is preferred as most packages use lib, so this will simply instrument everything thats not in the test or node_modules folder.
