### PR TITLE
Preserve original file name when loading scripts in nodejs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -98,6 +98,7 @@ if (!blanket.options("engineOnly")){
     //instrument js files
     require.extensions['.js'] = function(localModule, filename) {
         var pattern = blanket.options("filter");
+		var originalFilename = filename;
         filename = blanket.normalizeBackslashes(filename);
 
         //we check the never matches first
@@ -117,7 +118,7 @@ if (!blanket.options("engineOnly")){
                 var baseDirPath = blanket.normalizeBackslashes(path.dirname(filename))+'/.';
                 try{
                     instrumented = instrumented.replace(/require\s*\(\s*("|')\./g,'require($1'+baseDirPath);
-                    localModule._compile(instrumented, filename);
+                    localModule._compile(instrumented, originalFilename);
                 }
                 catch(err){
                     if (_blanket.options("ignoreScriptError")){


### PR DESCRIPTION
blanket normalizes filename and then loads them in node which causes stack traces to contain linux style path separators. If the user code is checking for a path on windows in a stack trace then the code breaks. The fix is to preserve original filename in call to localModule._compile
