### PR TITLE
Preserve original file name when loading scripts in nodejs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -98,7 +98,7 @@ if (!blanket.options("engineOnly")){
     //instrument js files
     require.extensions['.js'] = function(localModule, filename) {
         var pattern = blanket.options("filter");
-		var originalFilename = filename;
+        var originalFilename = filename;
         filename = blanket.normalizeBackslashes(filename);
 
         //we check the never matches first
@@ -135,7 +135,7 @@ if (!blanket.options("engineOnly")){
                 }
             });
         }else{
-            oldLoader(localModule,filename);
+            oldLoader(localModule, originalFilename);
         }
     };
 }


### PR DESCRIPTION
In the last commit didn't pass the originalFilename for uninstrumented files. Added that check now.
