### PR TITLE
Added check to reporting to exit gracefully

### DIFF
--- a/src/blanket_browser.js
+++ b/src/blanket_browser.js
@@ -152,6 +152,14 @@ _blanket.extend({
             _blanket.blanketSession = null;
         }
         coverage_data.files = window._$blanket;
+
+        // Check if we have any covered files that requires reporting
+        // otherwise just exit gracefully.
+        if (!coverage_data.files || !coverage_data.files.length) {
+            if (_blanket.options("debug")) {console.log("BLANKET-Reporting No files were instrumented.");}
+            return;
+        }
+
         if (typeof coverage_data.files.branchFcn !== "undefined"){
             delete coverage_data.files.branchFcn;
         }


### PR DESCRIPTION
When no files are being instrumented upon reporting, we should exit
gracefully. Otherwise the following error will stop JS execution:

```
Uncaught TypeError: Cannot read property 'branchFcn' of undefined
```

After some time of debugging, it was discovered due to config typing error. An error message like this would help others in case they have experienced the same error.
