### PR TITLE
Exit instrumentation when user redefines "window"

### DIFF
--- a/src/blanket.js
+++ b/src/blanket.js
@@ -205,7 +205,15 @@ var parseAndModify = (inBrowser ? window.falafel : require("falafel"));
             return function(node){
                 _blanket._blockifyIf(node);
 
-                if (linesToAddTracking.indexOf(node.type) > -1 && node.parent.type !== "LabeledStatement"){
+                if (linesToAddTracking.indexOf(node.type) > -1 && node.parent.type !== "LabeledStatement") {
+                    // Make sure developers don't redefine window. if they do, inform them it is wrong.
+                    if (node.type === "VariableDeclaration" && node.declarations) {
+                        node.declarations.forEach(function(declaration) {
+                            if (declaration.id.name === "window") {
+                                throw new Error("Instrumentation error, you cannot redefine the 'window' variable in  " + filename + ":" + node.loc.start.line);
+                            }
+                        });
+                    }
                     if (node.type === "VariableDeclaration" &&
                         (node.parent.type === "ForStatement" || node.parent.type === "ForInStatement")){
                         return;

--- a/test/lib-tests/blanket_test.js
+++ b/test/lib-tests/blanket_test.js
@@ -121,4 +121,21 @@ test('test events', function(){
     blanket.onTestStart();
     blanket.onTestDone();
     blanket.onTestsDone();
- });
+});
+
+test('instrumentation should fail user defined window declaration', function() {
+    throws(
+        function() {
+            var infile = "var loc=window.location.href; function getWindows() {console.log('updating location');\nvar window = ['black', 'transparent']; return window;} getWindows();";
+            var infilename= "testfile";
+            blanket.instrument({
+                inputFile: infile,
+                inputFileName: infilename
+            }, function(instrumented) {
+                eval(instrumented); // This should mess up and fail the throws test.
+            });
+        },
+        /testfile:2/,
+        "raised error message contains 'testfile:2'"
+    );
+});


### PR DESCRIPTION
The redefine of “window” in the middle of the function breaks code coverage because it depends on “window”. The reason why it breaks it is because JavaScript moves all variables to the top of the function. When adding instrumentation, var'ing “window” will cause it to be null from the start of the function that window._$blanket depends on.

For example this will fail:

```
!function (CustomWindow) {
    CustomWindow.flags = (function () {
      return {
        w: _w
     };
   })();
   var window = CustomWindow.flags.w; // Not valid code for instrumentation.
}
((window.CustomWindow = window.CustomWindow || {}));
```

It fails because JavaScript moves all variable declarations to the beginning of the function, causing this instrumentation code to fail:

```
window._$blanket= {};
window._$blanket["filea"] = [];
!function (CustomWindow) {
    var window;
    window._$blanket["filea"][0] += 1; // Fails
    CustomWindow.flags = (function () {
      window._$blanket["filea"][0] += 2;
      return {
        w: _w
     };
   })();
   window._$blanket["filea"][0] += 3;
   window = CustomWindow.flags.w;
   window._$blanket["filea"][0] += 4;
}
window._$blanket["filea"][0] += 5;
((window.CustomWindow = window.CustomWindow || {}));
window._$blanket["filea"][0] += 6;
```

The error the user just sees is from:

```
TypeError: Cannot call method _$blanket of null
```

Which pretty much can mean a lot of things in blanket, but if the user redefines "window" we should inform the user they are doing something wrong and throw and error back.
