### PR TITLE
#258: Added phantomjs as an npm dependency so that new developers do not have to manually install phantom to get npm test to work.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "xtend": "~2.0.3"
   },
   "devDependencies": {
+    "phantomjs": "1.8.2-0",
     "coffee-script": "1.4.0",
     "mocha": "1.7.4",
     "travis-cov": "*",

--- a/test/testconfigs.json
+++ b/test/testconfigs.json
@@ -32,7 +32,7 @@
     "browserChutzpah" :"test/requirejs/chutzpah.html?coverage=true"
   },
   "cmds": {
-    "phantom": "phantomjs",
+    "phantom": "./node_modules/phantomjs/bin/phantomjs",
     "mocha": "./node_modules/mocha/bin/mocha",
     "mochaCS": "./node_modules/mocha/bin/mocha --compilers coffee:coffee-script"
   }


### PR DESCRIPTION
Changes Include:
- package.json

Added a dev dependency to phantoms v1.8.2-0. This version was explicitly chosen because of a bug that occurs during the install process for phantomjs where the unzipped binary does not get moved to the right location. For more information on this bug, you can see it here: https://github.com/Obvious/phantomjs/issues/38
- test/testconfigs.json

Changed the "phantom" command to not rely on phantomjs to be on the PATH, it will instead reference the phantomjs that gets installed into node_modules by npm.
