### PR TITLE
Fix jasmine-blanket to correctly reference the correct execute() on the jasmine.Env object

### DIFF
--- a/src/adapters/jasmine-blanket.js
+++ b/src/adapters/jasmine-blanket.js
@@ -82,6 +82,9 @@
         callback:function(){
             jasmine.getEnv().addReporter(new jasmine.BlanketReporter());
             window.jasmine.getEnv().currentRunner().execute();
-            jasmine.getEnv().execute = jasmine.getEnv().currentRunner().execute;     }
+            jasmine.getEnv().execute = function () {
+                jasmine.getEnv().currentRunner().execute;   
+            };  
+        }
     });
 })();


### PR DESCRIPTION
When I include jasmine-blanket on my page and have code execute:

```
var jasmineEnv = jasmine.getEnv();
jasmineEnv.updateInterval = 1000;

// …

jasmineEnv.execute();
```

I get an error in the jasmine.Runner.prototype.execute function saying that the "reporter" property does not exist. This is due to line 72 of jasmine-blanket.js overriding the execute function on the environment object:

```
jasmine.getEnv().execute = function(){ console.log("waiting for blanket...");
```

And then changing the value again on line 85:

```
jasmine.getEnv().execute = jasmine.getEnv().currentRunner().execute;
```

This results in a problem due to my call to jasmineEnv.execute(); occurs after jasmine-blanket is done executing.

I believe the problem was a result of jasmine.getEnv().execute in jasmine-blanket becoming an explicit reference to the execute() function on the jamine.Runner object instead of jasmine.Env. When this occurs, the following code in jasmine.js is executed when I call jasmine.getEnv().execute() after I run jasmine-blanket.js:

```
jasmine.Runner.prototype.execute = function() {
  var self = this;
  if (self.env.reporter.reportRunnerStarting) {
    self.env.reporter.reportRunnerStarting(this);
  }
  self.queue.start(function () {
    self.finishCallback();
  });
};
```

HOWEVER, when a normal call to jasmine.getEnv().execute() occurs, the following code is executed:

```
jasmine.Env.prototype.execute = function() {
  this.currentRunner_.execute();
};
```

To fix this, I changed line 85 into a function that explicitly calls the execute() function on the currentRunner() attribute instead of just being a straight reference to the function.
