### PR TITLE
Fix original mocha.run() call to be invoked with the original callback

### DIFF
--- a/src/adapters/mocha-blanket.js
+++ b/src/adapters/mocha-blanket.js
@@ -49,13 +49,17 @@
 
             originalReporter(runner);
         };
-    
+
     mocha.reporter(blanketReporter);
     var oldRun = mocha.run;
-    mocha.run = function(){ console.log("waiting for blanket..."); };
+    var oldCallback = null;
+    mocha.run = function (finishCallback) {
+    	oldCallback = finishCallback;
+    	console.log("waiting for blanket...");
+    };
     blanket.beforeStartTestRunner({
         callback: function(){
-            oldRun();
+            oldRun(oldCallback);
             mocha.run = oldRun;
         }
     });


### PR DESCRIPTION
This commit fixes the mocha-blanket.js adapter to save off the original on "complete" callback and invoke mocha.run() with the saved off callback.
