### PR TITLE
Clearing away JSHint warnings

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,8 @@
+**/node_modules
+**/*[.-]min.js
+**/vendor
+test/usage
+**/js/ext
+test/bootstrap/tests
+test/commonjs/commonjs_bundle.js
+dist

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,6 @@
+{
+  "es5": true,
+  "expr": true,
+  "laxcomma": true,
+  "laxbreak": true
+}


### PR DESCRIPTION
I took a look with [JSHint](http://jshint.com/) for potential bugs. Most of the warnings output by `jshint .` were specific to dependencies like backbone, qunit, etc., so I excluded them with `.jshintignore`. In all, I was able to reduce about 3000 warnings down to a trim 670:

```
$ jshint .
src\blanketRequire.js: line 37, col 36, eval can be harmful.
src\blanketRequire.js: line 39, col 19, eval can be harmful.
src\blanketRequire.js: line 48, col 19, Use '!==' to compare with 'null'.

src\blanket_browser.js: line 110, col 27, ['blanketSessionLoader'] is better written in
dot notation.
src\blanket_browser.js: line 111, col 53, ['blanketSessionLoader'] is better written in
dot notation.
src\blanket_browser.js: line 208, col 31, ['blanketSessionLoader'] is better written in
dot notation.
src\blanket_browser.js: line 209, col 68, ['blanketSessionLoader'] is better written in
dot notation.
src\blanket_browser.js: line 266, col 37, eval can be harmful.

...

test\test-node\tests\blanket_core.js: line 111, col 24, eval can be harmful.
test\test-node\tests\blanket_core.js: line 126, col 11, eval can be harmful.

test\test-node\tests\instrumentation_test.js: line 60, col 11, eval can be harmful.
test\test-node\tests\instrumentation_test.js: line 62, col 48, ['branch_test_file2'] is
better written in dot notation.
test\test-node\tests\instrumentation_test.js: line 88, col 11, eval can be harmful.
test\test-node\tests\instrumentation_test.js: line 98, col 48, ['branch_test_file3'] is
better written in dot notation.

670 errors
```

I'm not familiar enough with blanket to resolve these myself, just thought I'd point them out.
