### PR TITLE
Add a better check for whether mocha is running from the command line

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -166,10 +166,23 @@ if ((process.env && process.env.BLANKET_COV===1) ||
     module.exports = blanketNode({engineOnly:true},false);
 }else{
     var args = process.argv;
+
+    var requireArgPosition = args.indexOf('--require');
+    if (requireArgPosition === -1) {
+      requireArgPosition = args.indexOf('-r');
+    }
+
+    var blanketRequired = false;
+    if (requireArgPosition &&
+        args[requireArgPosition + 1] &&
+        args[requireArgPosition + 1].match('blanket')) {
+      blanketRequired = true;
+    }
+
     if (args[0] === 'node' &&
         args[1].indexOf(join('node_modules','mocha','bin')) > -1 &&
-        (args.indexOf('--require') > 1 || args.indexOf('-r') > -1) &&
-         args.indexOf('blanket') > 2){
+        blanketRequired){
+
         //using mocha cli
         module.exports = blanketNode(null,true);
     }else{


### PR DESCRIPTION
The existing check misses cases where blanket is being require()'d from a relative path, e.g. ../node_modules/blanket, as it only tests for an argument matching "blanket".

This patch makes the test more robust in this situation.
