### PR TITLE
Fix statsForFile is undefined error.

### DIFF
--- a/dist/qunit/blanket.js
+++ b/dist/qunit/blanket.js
@@ -4777,6 +4777,10 @@ blanket.defaultReporter = function(coverage){
 
     for(var file in files)
     {
+        if (!files.hasOwnProperty(file)) {
+            break;
+        }
+
         fileNumber++;
 
         var statsForFile = files[file],


### PR DESCRIPTION
Added hasOwnProperty in loop to avoid statsForFile variable getting non self-defined property.
