### PR TITLE
Frameworks like Sinon.js overwrite the global XHR objects

### DIFF
--- a/src/blanketRequire.js
+++ b/src/blanketRequire.js
@@ -219,25 +219,25 @@ _blanket.extend({
             }
 
         },
-        createXhr: function(){
-            var xhr, i, progId;
+        cacheXhrConstructor: function(){
+            var Constructor, createXhr, i, progId;
             if (typeof XMLHttpRequest !== "undefined") {
-                return new XMLHttpRequest();
+                Constructor = XMLHttpRequest;
+                this.createXhr = function() { return new Constructor(); };
             } else if (typeof ActiveXObject !== "undefined") {
+                Constructor = ActiveXObject;
                 for (i = 0; i < 3; i += 1) {
                     progId = progIds[i];
                     try {
-                        xhr = new ActiveXObject(progId);
-                    } catch (e) {}
-
-                    if (xhr) {
-                        progIds = [progId];  // so faster next time
+                        new ActiveXObject(progId);
                         break;
-                    }
+                    } catch (e) {}
                 }
+                this.createXhr = function() { return new Constructor(progId); };
             }
-
-            return xhr;
+        },
+        craeteXhr: function () {
+            throw new Error("cacheXhrConstructor is supposed to overwrite this function.");
         },
         getFile: function(url, callback, errback, onXhr){
             var foundInSession = false;
@@ -323,6 +323,8 @@ _blanket.extend({
             });
         };
     }
+    // Save the XHR constructor, just in case frameworks like Sinon would sandbox it.
+    _blanket.utils.cacheXhrConstructor();
 })();
 
 })(blanket);

--- a/test/requirejs/code/all.tests.qunit.js
+++ b/test/requirejs/code/all.tests.qunit.js
@@ -1,6 +1,10 @@
 ﻿/// <reference path="require.js" />
 /// <reference path="qunit.js" />
 
+// Blanket should save the XHR just in case there's a test that overwrites them.
+window.XMLHttpRequest = null;
+window.ActiveXObject = null;
+
 requirejs(['./tests/base/base.qunit.test',
            './tests/ui/ui.qunit.test'],
     function (){}


### PR DESCRIPTION
When tests are using Sinon.js to sandbox the XHR objects, Blanket.js will just fail to load the required files. This patch will create a copy of the XHR constructors when Blanket.js loads.

http://sinonjs.org/docs/#FakeXMLHttpRequest
