### PR TITLE
mention script-include-order in getting_started_browser.md

### DIFF
--- a/docs/getting_started_browser.md
+++ b/docs/getting_started_browser.md
@@ -10,7 +10,7 @@ To begin you will need:
 
 1. Download [Blanket.js](https://raw.github.com/alex-seville/blanket/master/dist/qunit/blanket.min.js) or `bower install blanket`
 
-2. Reference the script in the testrunner HTML file as follows:
+2. Reference the script in the testrunner HTML file (after, not before, `qunit.js`) as follows:
 ```
 <script src="blanket.min.js"></script>
 ```


### PR DESCRIPTION
found that if you include blanket at the top, it fails without error message (even with the debug flag on) in both FF and Chrome. by comparing to http://blanketjs.org/examples/backbone-koans-qunit/index.html?coverage=true step-by-step, i found out what i was doing wrong. maybe worth mentioning in the instructions in case more people maybe the same noob error :)
