### PR TITLE
Update xtend dependency and change engine to 0.10.*

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
   ],
   "main": "src/index.js",
   "engines": {
-    "node": "0.10.7"
+    "node": "0.10.*"
   },
   "dependencies": {
     "esprima": "~1.0.2",
     "falafel": "~0.1.6",
-    "xtend": "~2.0.3"
+    "xtend": "~2.1.1"
   },
   "devDependencies": {
     "phantomjs": "1.8.2-0",


### PR DESCRIPTION
- Allow any node v0.10.\* versions (previous setting yielded a warning)
- Updating xtend dependency (previous version used deprecated object-keys version)
