### PR TITLE
update engines in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "main": "src/index.js",
   "engines": {
-    "node": "0.10.7"
+    "node": ">=0.10.7"
   },
   "dependencies": {
     "esprima": "~1.0.2",


### PR DESCRIPTION
remove npm WARN engine blanket@1.1.5: wanted: {"node":"0.10.7"}
(current: {"node":"v0.10.21","npm":"1.3.11"}) when npm install
