### PR TITLE
New version of mocha requires suiteURL function

### DIFF
--- a/src/adapters/mocha-blanket.js
+++ b/src/adapters/mocha-blanket.js
@@ -47,8 +47,10 @@
             //I dont know why these became global leaks
             runner.globals(['stats', 'failures', 'runner']);
 
-            originalReporter(runner);
+            originalReporter.call(this, runner);
         };
+
+    blanketReporter.prototype = mocha._reporter.prototype;
 
     mocha.reporter(blanketReporter);
     var oldRun = mocha.run,


### PR DESCRIPTION
It's similar problem to https://github.com/kmiyashiro/grunt-mocha/pull/92. Mocha requires suiteURL function, without this changes it not work in browser environment.
