### PR TITLE
include relative path from cwd in shortnames

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -142,7 +142,7 @@ var blanketNode = function (userOptions,cli){
                 if (_blanket.options("debug")) {console.log("BLANKET-Attempting instrument of:"+filename);}
                 var content = fs.readFileSync(filename, 'utf8');
                 if (reporter_options && reporter_options.shortnames){
-                    filename = filename.replace(path.dirname(filename),"");
+                    filename = filename.replace(process.cwd(),"");
                 }
 
                 blanket.instrument({


### PR DESCRIPTION
this is done so 2 files in 2 different folders with the same name are still distinguishable in the output
