### PR TITLE
Safer way to judge using mocha cli or not.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -187,17 +187,21 @@ if ((process.env && process.env.BLANKET_COV===1) ||
 }else{
     var args = process.argv;
 
-    var requireArgPosition = args.indexOf('--require');
-    if (requireArgPosition === -1) {
-      requireArgPosition = args.indexOf('-r');
+    function findBlanketRequired(args, pos) {
+        pos = pos || 0;
+        var requireArgPosition = args.indexOf('--require', pos);
+        (requireArgPosition === -1) && (requireArgPosition = args.indexOf('-r', pos));
+        if (requireArgPosition === -1) {
+            return false;
+        } else if (args[requireArgPosition + 1] &&
+            args[requireArgPosition + 1].match('blanket')) {
+            return true;
+        } else {
+            return findBlanketRequired(args, requireArgPosition + 1);
+        }
     }
 
-    var blanketRequired = false;
-    if (requireArgPosition &&
-        args[requireArgPosition + 1] &&
-        args[requireArgPosition + 1].match('blanket')) {
-      blanketRequired = true;
-    }
+    var blanketRequired = findBlanketRequired(args);
 
     if (args[0] === 'node' &&
         args[1].indexOf(join('node_modules','mocha','bin')) > -1 &&


### PR DESCRIPTION
Sometimes, It doesn't show coverage for files (node + mocha).
I found that this is not a safe way to judge using mocha cli or not:

```
    var blanketRequired = false;
    if (requireArgPosition &&
        args[requireArgPosition + 1] &&
        args[requireArgPosition + 1].match('blanket')) {
      blanketRequired = true;
    }
```

Sometimes args can be: 
[ 'node', 'C:\Users\miniflycn\AppData\Roaming\npm\node_modules\mocha\bin_mocha', '--require', 'should', '--timeout', '5000', '--require', 'blanket', '-R', 'html-cov' ]
