### PR TITLE
create the original mocha reporter

### DIFF
--- a/src/adapters/mocha-blanket.js
+++ b/src/adapters/mocha-blanket.js
@@ -45,7 +45,7 @@
             });
 
             // NOTE: this is an instance of BlanketReporter
-            OriginalReporter.apply(this, arguments);
+            new OriginalReporter(runner);
         };
 
     mocha.reporter(BlanketReporter);


### PR DESCRIPTION
mocha's [~1.17.1] default HTML reporter is a function object. It needs to be instantiated to work correctly. note that I haven't tested it with other reporters, but there shouldn't be any side-effects.
