### PR TITLE
fix LCOV reporter when toHTML option is false

### DIFF
--- a/src/reporters/lcov_reporter.js
+++ b/src/reporters/lcov_reporter.js
@@ -25,14 +25,17 @@
             div.innerText = str;
             body.appendChild(div);
         }else{
-            window._$blanket_LCOV = str;
+            window._$blanket_LCOV += str;
         }
     };
 
     blanket.customReporter=function(coverageData,options){
         var toHTML=true;
+
+        window._$blanket_LCOV = '';
+
         if (typeof options !== 'undefined' && typeof options.toHTML !== 'undefined'){
-            toHTML = options.toHTML;
+          toHTML = options.toHTML;
         }
         for (var filename in coverageData.files) {
           var data = coverageData.files[filename];


### PR DESCRIPTION
Hi,

Once we run LCOV reporter with the option _toHTML_ as false, it set only the last file coverage result.

I've fixed that creating the global attribute `_$blanket_LCOV` as soon as blanket.customReporter is called, then I increment the same. I thought to implement inside the conditional `options.toHTML !== 'undefined'` before, but it can inherit old results in some cases.

An alternative to let each file result separated(the same way as html) is turning `_$blanket_LCOV` into array.

So, what do you think?

Cheers!
