### PR TITLE
Fix LCOV coverage reporting for toHTML=false

### DIFF
--- a/src/reporters/lcov_reporter.js
+++ b/src/reporters/lcov_reporter.js
@@ -25,7 +25,7 @@
             div.innerText = str;
             body.appendChild(div);
         }else{
-            window._$blanket_LCOV = str;
+            window._$blanket_LCOV = (window._$blanket_LCOV || '') + str;
         }
     };
 


### PR DESCRIPTION
Report coverage data for each file to window._$blanket_LCOV

see https://github.com/alex-seville/blanket/issues/402
