### PR TITLE
Update mocha-blanket.js

### DIFF
--- a/src/adapters/mocha-blanket.js
+++ b/src/adapters/mocha-blanket.js
@@ -47,6 +47,8 @@
             // NOTE: this is an instance of BlanketReporter
             OriginalReporter.apply(this, arguments);
         };
+        
+    BlanketReporter.prototype = OriginalReporter.prototype;
 
     mocha.reporter(BlanketReporter);
 


### PR DESCRIPTION
The current release of mocha does not work unless the BlanketReporter inherits the prototype from OriginalReporter
