### PR TITLE
Improve LCOV reporter and fix bug when toHTML set to false

### DIFF
--- a/src/reporters/lcov_reporter.js
+++ b/src/reporters/lcov_reporter.js
@@ -4,7 +4,7 @@
 
     var body = document.body;
 
-    var appendHtml = function(filename, data, toHTML) {
+    var appendResult = function(filename, data, options) {
 
         var str = "";
         str += 'SF:' + filename + '\n';
@@ -20,7 +20,7 @@
 
         str += 'end_of_record\n';
 
-        if (toHTML) {
+        if (options.toHTML) {
             var div = document.createElement('div');
             div.className = "blanket_lcov_reporter";
             div.innerText = str;
@@ -31,15 +31,13 @@
     };
 
     blanket.customReporter = function(coverageData, options) {
-        var toHTML = true;
-
-        if (typeof options !== 'undefined' && typeof options.toHTML !== 'undefined') {
-            toHTML = options.toHTML;
-        }
+        options = options || {
+            toHTML: true
+        };
 
         for (var filename in coverageData.files) {
             var data = coverageData.files[filename];
-            appendHtml(filename, data, toHTML);
+            appendResult(filename, data, options);
         }
     };
 


### PR DESCRIPTION
Similar to (if not identical to) #402, #403, #391 but asking for merge into develop instead of master.

Aside from fixing the issue with the lcov data not being appended to the global variable, I've also improved some of the internal API slightly.
