### PR TITLE
Set default pattern to src

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,10 +25,6 @@ var blanketNode = function (userOptions,cli){
     }
 
     var blanketConfigs = packageConfigs ? extend(packageConfigs,userOptions) : userOptions,
-
-        pattern = blanketConfigs  ?
-                          blanketConfigs.pattern :
-                          "src",
         blanket = require("./blanket").blanket,
         oldLoader = require.extensions['.js'],
         newLoader;
@@ -37,7 +33,9 @@ var blanketNode = function (userOptions,cli){
         return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
     }
     if (blanketConfigs){
-        var newOptions={};
+        var newOptions={
+            'filter': 'src' // Default filter to src
+        };
         Object.keys(blanketConfigs).forEach(function (option) {
             var optionValue = blanketConfigs[option];
             if(option === "data-cover-only" || option === "pattern"){
@@ -71,6 +69,9 @@ var blanketNode = function (userOptions,cli){
             }
         });
         blanket.options(newOptions);
+    } else {
+        // If no config is specified, default filter to src.
+        blanket.options('filter', 'src');
     }
 
     //helper functions


### PR DESCRIPTION
Fixes https://github.com/alex-seville/blanket/issues/430.

Set the default pattern to `src` if the config is missing or if a pattern has not been explicitly set in the config.

I am looking for guidance on the best way to test this. I have three test cases in mind:

```javascript
describe('default configuration', function() {
  describe('should use src as the default pattern', function() {
    it('missing configuration should still contain a default pattern', function() {
      var blanket = require('../../../src/index')();
      console.log(blanket.options('filter'));
      assert.equal(blanket.options('filter'), 'src');
    });

    it('config missing pattern should still set a default pattern', function() {
      var blanket = require('../../../src/index')({});
      assert.equal(blanket.options('filter'), 'src');
    })

    it('pattern in config should override the default', function() {
      var blanket = require('../../../src/index')({ pattern: 'foo' });
      assert.equal(blanket.options('filter'), 'foo');
    })
  });
});
```

However, these three tests fall down due to the default pattern already specified in the package.json which gets picked up. Any thoughts on a way to get these tests running?

I tried to make this PR against the development branch but it seems like the Gruntfile is incorrectly named and the tests aren't working. Am I missing something? Should I rebase against development and re-compare?