### PR TITLE
Add more helpful information to error message

### DIFF
--- a/src/blanketRequire.js
+++ b/src/blanketRequire.js
@@ -115,13 +115,13 @@ _blanket.extend({
            var timeout = _blanket.options("timeout") || 3000;
            setTimeout(function(){
                 if (!_blanket.utils.cache[options.url].loaded){
-                    throw new Error("error loading source script");
+                    throw new Error("error (timeout=" + timeout + ") loading source script: " + options.url);
                 }
            },timeout);
            _blanket.utils.getFile(
                 options.url,
                 cb,
-                function(){ throw new Error("error loading source script");}
+                function(){ throw new Error("error loading source script: " + options.url);}
             );
         },
         ifOrdered: function(nextScript,cb){


### PR DESCRIPTION
Added information detailing what script failed to load, and also added the timeout value in the timeout condition's error message.

Our project was running into the default 180ms timeout in certain cases and it was unclear what was happening.