### PR TITLE
Fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: node_js
 node_js:
   - 0.8
+  - 0.9
+  - 0.10
+
+before_install: "if [[ $(node --version) =~ v0.[89].* ]]; then npm install -g npm@1.3; fi"
 
 branches:
   only:


### PR DESCRIPTION
Attempting to fix Travis builds. The problem is version 1.3 of npm added a new version syntax (`foo@^1.0.5`) that older npm barfs on.
Also added tests for more versions of node.