### PR TITLE
Fix alternative node.js runtimes for mocha

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -200,7 +200,7 @@ if ((process.env && process.env.BLANKET_COV===1) ||
         }
     }
 
-    if (args[0] === 'node' &&
+    if (path.basename(args[0]).indexOf(['node', 'iojs', 'nodejs', 'jx']) > -1 &&
         args[1].indexOf(join('node_modules','mocha','bin')) > -1 &&
         blanketRequired){
 


### PR DESCRIPTION
This is related to mochajs/mocha#1585, yamadapc/mocha-spec-cov-alt#3 and
possibly other issues in other repositories.

`mocha` spawns a child process `_mocha` in order to support custom
node.js flags being passed into it.

The newest version of `mocha` (2.2) uses `process.execPath` rather than
`process.argv[0]` to spawn the child. This is meant to be able to have
better support for things like `io.js`. Because of that,
`process.argv[0]` in this line of `blanket` is set to the absolute path
to the node.js/io.js/etc. executable, rather than `node`.

This fixes that problem by comparing the `basename` of `process.argv[0]`
with a list of appropriate executable names.

It therefore fixes compatibility with `mocha >= 2.2`.