### PR TITLE
Allow explicit specification of scripts in browser without <script>

### DIFF
--- a/src/blanketRequire.js
+++ b/src/blanketRequire.js
@@ -40,27 +40,32 @@ _blanket.extend({
             var toArray = Array.prototype.slice;
             var scripts = toArray.call(document.scripts);
             var selectedScripts=[],scriptNames=[];
+            var scriptNamesOpt = _blanket.options("scriptNames");
             var filter = _blanket.options("filter");
-            if(filter != null){
-                //global filter in place, data-cover-only
-                var antimatch = _blanket.options("antifilter");
-                selectedScripts = toArray.call(document.scripts)
-                                .filter(function(s){
-                                    return toArray.call(s.attributes).filter(function(sn){
-                                        return sn.nodeName === "src" && _blanket.utils.matchPatternAttribute(sn.nodeValue,filter) &&
-                                            (typeof antimatch === "undefined" || !_blanket.utils.matchPatternAttribute(sn.nodeValue,antimatch));
-                                    }).length === 1;
-                                });
+            if(scriptNamesOpt != null){ 
+                scriptNames = scriptNamesOpt.split(/\s*,\*/);
             }else{
-                selectedScripts = toArray.call(document.querySelectorAll("script[data-cover]"));
-            }
-            scriptNames = selectedScripts.map(function(s){
-                                    return _blanket.utils.qualifyURL(
-                                        toArray.call(s.attributes).filter(
-                                            function(sn){
-                                                return sn.nodeName === "src";
-                                            })[0].nodeValue);
+                if(filter != null){
+                    //global filter in place, data-cover-only
+                    var antimatch = _blanket.options("antifilter");
+                    selectedScripts = toArray.call(document.scripts)
+                                    .filter(function(s){
+                                        return toArray.call(s.attributes).filter(function(sn){
+                                            return sn.nodeName === "src" && _blanket.utils.matchPatternAttribute(sn.nodeValue,filter) &&
+                                                (typeof antimatch === "undefined" || !_blanket.utils.matchPatternAttribute(sn.nodeValue,antimatch));
+                                        }).length === 1;
                                     });
+                }else{
+                    selectedScripts = toArray.call(document.querySelectorAll("script[data-cover]"));
+                }
+                scriptNames = selectedScripts.map(function(s){
+                                        return _blanket.utils.qualifyURL(
+                                            toArray.call(s.attributes).filter(
+                                                function(sn){
+                                                    return sn.nodeName === "src";
+                                                })[0].nodeValue);
+                                        });
+            }
             if (!filter){
                 _blanket.options("filter","['"+scriptNames.join("','")+"']");
             }

--- a/src/blanketRequire.js
+++ b/src/blanketRequire.js
@@ -43,7 +43,7 @@ _blanket.extend({
             var scriptNamesOpt = _blanket.options("scriptNames");
             var filter = _blanket.options("filter");
             if(scriptNamesOpt != null){ 
-                scriptNames = scriptNamesOpt.split(/\s*,\*/);
+                scriptNames = scriptNamesOpt.split(/\s*,\s*/);
             }else{
                 if(filter != null){
                     //global filter in place, data-cover-only

--- a/src/config.js
+++ b/src/config.js
@@ -5,6 +5,9 @@
     var scripts = toArray.call(document.scripts);
     toArray.call(scripts[scripts.length - 1].attributes)
                     .forEach(function(es){
+                        if(es.nodeName === "data-cover-scripts"){
+                            newOptions.scriptNames = es.nodeValue;
+                        }
                         if(es.nodeName === "data-cover-only"){
                             newOptions.filter = es.nodeValue;
                         }

--- a/src/config.js
+++ b/src/config.js
@@ -5,7 +5,7 @@
     var scripts = toArray.call(document.scripts);
     toArray.call(scripts[scripts.length - 1].attributes)
                     .forEach(function(es){
-                        if(es.nodeName === "data-cover-scripts"){
+                        if(es.nodeName === "data-cover-instrument-load-scripts"){
                             newOptions.scriptNames = es.nodeValue;
                         }
                         if(es.nodeName === "data-cover-only"){


### PR DESCRIPTION
This small patch introduces a new 'scriptNames' option specified by 'data-cover-scripts' which allows user to explicitly list scripts to load and cover, without requiring loading and pre-evaluation via `<script>` tag.

Currently instrumented source is run (evaluated) twice: once by the browser via the script tag, and then *again* after the source is instrumented by blanket.  This is because blanket relies exclusively on the presence of `<script>` tags to determine user scripts for instrumentation.  In some cases source must only be run once (e.g. setup of immutable globals, etc.).  This can be accomplished by permitting a mechanism, other than `<script>` tag, for the user to specify scripts.

e.g.:

```
<script data-cover-scripts="./test/test.js" src="./bower_components/blanket/dist/qunit/blanket.js"></script>
<!-- don't make the browser load the script
<script src="./test/test.js" data-cover></script>
-->
```