### PR TITLE
add support for <blanket> script element

### DIFF
--- a/src/blanketRequire.js
+++ b/src/blanketRequire.js
@@ -38,13 +38,19 @@ _blanket.extend({
         },
         collectPageScripts: function(){
             var toArray = Array.prototype.slice;
-            var scripts = toArray.call(document.scripts);
             var selectedScripts=[],scriptNames=[];
             var filter = _blanket.options("filter");
+
+            function selectAllScripts() {
+              var browserScripts = toArray.call(document.scripts);
+              var blanketScripts = toArray.call(document.getElementsByTagName('blanket'));
+              return browserScripts.concat(blanketScripts);
+            }
+
             if(filter != null){
                 //global filter in place, data-cover-only
                 var antimatch = _blanket.options("antifilter");
-                selectedScripts = toArray.call(document.scripts)
+                selectedScripts = selectAllScripts()
                                 .filter(function(s){
                                     return toArray.call(s.attributes).filter(function(sn){
                                         return sn.nodeName === "src" && _blanket.utils.matchPatternAttribute(sn.nodeValue,filter) &&
@@ -52,7 +58,7 @@ _blanket.extend({
                                     }).length === 1;
                                 });
             }else{
-                selectedScripts = toArray.call(document.querySelectorAll("script[data-cover]"));
+                selectedScripts = toArray.call(document.querySelectorAll("script[data-cover], blanket"));
             }
             scriptNames = selectedScripts.map(function(s){
                                     return _blanket.utils.qualifyURL(


### PR DESCRIPTION
Allows specification of instrumented scripts which are _not_ loaded by browser. See #480