### PR TITLE
escape ` $ & characters in escapeInvalidXmlChars to avoid triggering special replacement behavior when processing the source for the report using String.prototype.replace

### DIFF
--- a/src/qunit/reporter.js
+++ b/src/qunit/reporter.js
@@ -42,7 +42,10 @@ blanket.defaultReporter = function(coverage){
             .replace(/</g, "&lt;")
             .replace(/\>/g, "&gt;")
             .replace(/\"/g, "&quot;")
-            .replace(/\'/g, "&apos;");
+            .replace(/\'/g, "&apos;")
+            .replace(/`/g, "&grave;")
+            .replace(/[$]/g, "&dollar;")
+            .replace(/&/g, "&amp;");
     }
 
     function isBranchFollowed(data,bool){


### PR DESCRIPTION
If in your source code you use $` then it will break the html structure in the browser report and result in partial browser reports. $` has special meanings for String.prototype.replace.

for more detail see "Specifying a string as a parameter" in https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying a string as a parameter