### PR TITLE
Consider before and after hooks calls covered

### DIFF
--- a/src/adapters/mocha-blanket.js
+++ b/src/adapters/mocha-blanket.js
@@ -44,6 +44,14 @@
                 blanket.onTestDone(test.parent.tests.length, test.state === 'passed');
             });
 
+            runner.on('hook', function(){
+                blanket.onTestStart();
+            });
+
+            runner.on('hook end', function(){
+                blanket.onTestsDone();
+            });
+
             // NOTE: this is an instance of BlanketReporter
             new OriginalReporter(runner);
         };


### PR DESCRIPTION
In order to count code called in beforeEach hooks as covered, add onTestStart / onDestsDone calls to 'hook' and 'hook end' calls.

This is necessary to support the common pattern of a single setup block, and very simple tests that check various conditions after that setup.