### PR TITLE
Adds grunt-cli to dev dependencies and npm build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ See the [Compatiblity and Feature List](https://github.com/alex-seville/blanket/
 1. `git clone git@github.com:alex-seville/blanket.git`  
 2. `npm install`  
 3. Add your custom build details to the grunt.js file under `concat`
-3. `grunt buildit` 
+3. `npm run build` 
 
 A minified and unminfied copy of the source can be created (see the `min` task).  
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "async": "~0.9.0",
     "coffee-script": "~1.7.1",
     "grunt": "~0.4.5",
+    "grunt-cli": "^0.1.13",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-concat": "~0.4.0",
     "grunt-contrib-jshint": "~0.10.0",
@@ -46,6 +47,7 @@
     "uglify-save-license": "~0.4.1"
   },
   "scripts": {
+    "build": "grunt build",
     "test": "grunt --verbose blanketTest"
   },
   "config": {


### PR DESCRIPTION
@alex-seville I was working on an issue with the package and when tried to build the distribution files, failed because `grunt` was not found. If someone does not have `grunt-cli` installed globally, it should be installed through `npm install`.

Additionally, a `build` script was added for convenience in the `package.json` and the documentation corrected.

In the case `grunt` and `grunt-cli` are installed globally, running just `grunt` will build the package as usual.