### PR TITLE
Clarifies how array of patters have to be written

### DIFF
--- a/docs/intermediate_browser.md
+++ b/docs/intermediate_browser.md
@@ -21,7 +21,7 @@ NOTE: PhantomJS and other third-party JS runtimes may not support synchronous XH
 
 4. Add a `data-cover-only` attribute to avoid having to add `data-cover` to each script you want covered.  You can pass the filter value as a string to match, an array of filename, or a regular expression (add a double slash to the start, i.e. `data-cover-only="//.*/"`):
     ```<script src="blanket.min.js" data-cover-adapter="jasmine-blanket.js"  
-        data-cover-only="['source1.js','src/source2.js']"></script>```
+        data-cover-only="[source1.js,src/source2.js]"></script>```
 
 5. Add a `data-cover-modulepattern` attribute to have the reporter generate total coverage statistics for each module in your application.  (*Currently only supported using QUnit reporter.*)  This is useful for tracking code coverage across multiple teams that work on different modules.  Modules are determined by the regular expression pattern you pass via this attribute.  The regular expression is expected to have one pattern matching section in parenthesis, which will be captured as the module name.  For example, let's say that the files in your blanket report look like this:
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -77,7 +77,7 @@ This guide details all the configuration options available for the browser versi
   result: the file `sourcefile89.js` would be covered.
 
   array: data-cover-only="[<comma separated list of strings, regular expressions, arryas or functions>]"
-  example: data-cover-only="['src/','modules/']"
+  example: data-cover-only="[src/,modules/]"
   result: files contains `src/` and `modules/` in their files paths will be covered.
 
   function: data-cover-only="#<function declaration or function name>"
@@ -95,7 +95,7 @@ This guide details all the configuration options available for the browser versi
   result: the file `sourcefile89.js` would be excluded from coverage.
 
   array: data-cover-never="[<comma separated list of strings, regular expressions, arryas or functions>]"
-  example: data-cover-never="['src/','modules/']"
+  example: data-cover-never="[src/,modules/]"
   result: files contains `src/` and `modules/` in their files paths will be excluded from coverage.
 
   function: data-cover-never="#<function declaration or function name>"


### PR DESCRIPTION
@alex-seville checking the code and the docs, I saw the `data-cover-*` values as described in the docs are incorrect when specifying arrays.

The code of `matchPatternAttribute` at `src/blanketRequire.js` receives the array of patterns as a string, then discards the squared brackets and splits the remaining string at every comma. Each part is then used recursively as the matching pattern so no `'` should be added.

This is related to the docs change discussed in #156.