### PR TITLE
Prevent "waiting for blanket" message if it is loaded by RequireJS

### DIFF
--- a/src/blanket_browser.js
+++ b/src/blanket_browser.js
@@ -182,7 +182,11 @@ _blanket.extend({
         if (bindEvent){
             bindEvent(startEvent);
         }else{
-            window.addEventListener("load",startEvent,false);
+            if (document.readyState === "complete") {
+                startEvent();
+            } else {
+                window.addEventListener("load",startEvent,false);
+            }
         }
     },
     _loadSourceFiles: function(callback){


### PR DESCRIPTION
@alex-seville @fearphage I run into a similar problem to #443.

The problem is that is @boyander is loading `blanket` through `require` itself. In that case, the document is fully loaded before `blanket`is loaded. Therefore, the `load` event on the `window` is triggered before `_bindStartTestRunner` is executed and `mocha.run` is never restored to allow `mocha` to do its job.

One workaround to allow `blanket` to be compatible with loading it using `require` instead of adding it using a `script` tag is to detect if the document is fully loaded or not just at that point. In the case it was loaded using `require`, just let the flow continue. If not, wait for the `load` event as usual.

The whole-AMD setup for both Mocha and Blanket should be:

``` HTML
<html>
  <head>
    <link rel="stylesheet" href="libs/mocha/mocha.css"/>
  </head>
  <body>
    <div id="mocha"></div>
    <script src="libs/mocha/require.js" data-main="specRunner.js"></script>
  </body>
</html>
```

And the runner should be:

``` javascript
require.config({
        'mocha': 'libs/mocha/mocha',
        'blanket': 'libs/blanket/dist/mocha/blanket_mocha'
    },
    shim: {
        'blanket': {
            deps: ['mocha']
        }
    }
});
require([
    'blanket',
    'mocha',
], function () {
    // setup mocha and blanket options here
    require([
        'test-script'
    ], function () {
        mocha.run();
    });
});
```