### PR TITLE
Normalize backslashes in Windows environments. (master)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -130,8 +130,8 @@ var blanketNode = function (userOptions,cli){
             var pattern = blanket.options("filter"),
                 reporter_options = blanket.options("reporter_options"),
                 originalFilename = filename,
-			inputFilename = filename;
-            filename = blanket.normalizeBackslashes(filename);
+                inputFilename = blanket.normalizeBackslashes(filename);
+            filename = inputFilename;
 
             //we check the never matches first
             var antipattern = _blanket.options("antifilter");


### PR DESCRIPTION
#502 but branched from master instead of develop.

See #491.

NOTE: `grunt` fails on the blanketTest stage right now complaining that it can't run a Mocha executable that clearly exists.  Perhaps a different Windows-only problem?  Anyway, because of this I wasn't able to run the tests myself.