### PR TITLE
Parser errors now available in thrown Error

### DIFF
--- a/dist/jasmine/blanket_jasmine.js
+++ b/dist/jasmine/blanket_jasmine.js
@@ -5098,7 +5098,9 @@ _blanket.extend({
                             cb(content);
                             _blanket.requiringFile(url,true);
                         }else{
-                            throw new Error("Error parsing instrumented code: "+err);
+                            var e = new Error("Error parsing instrumented code: "+err);
+                            e.error = err;
+                            throw e;
                         }
                     }
                 });

--- a/dist/mocha/blanket_mocha.js
+++ b/dist/mocha/blanket_mocha.js
@@ -5098,7 +5098,9 @@ _blanket.extend({
                             cb(content);
                             _blanket.requiringFile(url,true);
                         }else{
-                            throw new Error("Error parsing instrumented code: "+err);
+                            var e = new Error("Error parsing instrumented code: "+err);
+                            e.error = err;
+                            throw e;
                         }
                     }
                 });

--- a/dist/qunit/blanket.js
+++ b/dist/qunit/blanket.js
@@ -5099,7 +5099,9 @@ _blanket.extend({
                             cb(content);
                             _blanket.requiringFile(url,true);
                         }else{
-                            throw new Error("Error parsing instrumented code: "+err);
+                            var e = new Error("Error parsing instrumented code: "+err);
+                            e.error = err;
+                            throw e;
                         }
                     }
                 });

--- a/src/blanketRequire.js
+++ b/src/blanketRequire.js
@@ -208,7 +208,9 @@ _blanket.extend({
                             cb(content);
                             _blanket.requiringFile(url,true);
                         }else{
-                            throw new Error("Error parsing instrumented code: "+err);
+                            var e = new Error("Error parsing instrumented code: "+err);
+                            e.error = err;
+                            throw e;
                         }
                     }
                 });

--- a/src/index.js
+++ b/src/index.js
@@ -171,7 +171,9 @@ var blanketNode = function (userOptions,cli){
                             if (_blanket.options("debug")) {console.log("BLANKET-There was an error loading the file:"+filename);}
                             oldLoader(localModule,filename);
                         }else{
-                            throw new Error("BLANKET-Error parsing instrumented code: "+err);
+                            var e = new Error("BLANKET-Error parsing instrumented code: "+err);
+                            e.error = err;
+                            throw e;
                         }
                     }
                 });


### PR DESCRIPTION
Errors thrown by Blanket while parsing source code are now bubbled up in
the error thrown for error reporting.