### PR TITLE
Fix deprecated license format using SPDX

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,7 @@
   "bugs": {
     "url": "https://github.com/alex-seville/blanket/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/alex-seville/blanket/blob/master/LICENSE-MIT"
-    }
-  ],
+  "license": "MIT",
   "main": "src/index.js",
   "engines": {
     "node": ">=0.10.7"


### PR DESCRIPTION
See: https://docs.npmjs.com/files/package.json#license

This fixes the following warning:

    npm WARN package.json blanket@1.1.7 No license field.