### PR TITLE
Console color updates for Chrome, Firefox, and Internet Explorer too.

### DIFF
--- a/test/helpers/console_runner.js
+++ b/test/helpers/console_runner.js
@@ -113,5 +113,33 @@
     console.log(text);
   };
 
+  function cssLog(str, color) {
+    if (color !== undefined) {
+        console.log('%c' + str, 'color: ' + color);
+    } else {
+        console.log(str);
+    }
+  };
+
+  function isChromeConsole() {
+    if (!window) {
+      return;
+    }
+    return !!window.chrome;
+  }
+  if (isChromeConsole()) {
+    proto.log = cssLog;
+  }
+
+  function isFirefoxConsole() {
+    if (!window || !window.console) {
+      return;
+    }
+    return window.console.firebug || window.console.exception;
+  }
+  if (isFirefoxConsole()) {
+    proto.log = cssLog;
+  }
+
   jasmine.ConsoleReporter = ConsoleReporter;
 })(jasmine, console);

--- a/test/helpers/console_runner.js
+++ b/test/helpers/console_runner.js
@@ -121,6 +121,27 @@
     }
   };
 
+  function isExplorerConsole() {
+    if (!window || !window.console) {
+      return;
+    }
+    return window.console.clear;
+  }
+  function logTypes(str, color) {
+    if (color === undefined) {
+      console.log(str);
+    }
+    if (color === 'green') {
+      console.info(str);
+    }
+    if (color === 'red') {
+      console.error(str);
+    }
+  }
+  if (isExplorerConsole()) {
+    proto.log = logTypes;
+  }
+
   function isChromeConsole() {
     if (!window) {
       return;


### PR DESCRIPTION
Using blanket via web browsers currently results in the ANSI color codes not being supported by their consoles.

This is a fix for both Chrome and Firefox, along with optionally Internet Explorer too.

Details on the Chrome and Firefox console colors are found at http://developer.chrome.com/devtools/docs/console-api#consolelogobject-object and https://getfirebug.com/wiki/index.php/Console.log

Whereas with Internet Explorer we can use console.info and console.error to obtain a suitable display on its console.