### PR TITLE
migrate component.json to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,31 @@
+{
+  "name": "blanket",
+  "version": "1.1.7",
+  "main": [
+    "./dist/qunit/blanket.js"
+  ],
+  "homepage": "https://github.com/alex-seville/blanket",
+  "authors": [
+    "Alex-Seville <hi@alexanderseville.com>"
+  ],
+  "description": "blanket.js is a simple code coverage library for javascript",
+  "moduleType": [
+    "amd",
+    "globals",
+    "node"
+  ],
+  "keywords": [
+    "code-coverage",
+    "coverage",
+    "unit",
+    "test"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}

--- a/component.json
+++ b/component.json
@@ -1,5 +1,0 @@
-{
-  "name": "blanket",
-  "version": "1.1.7",
-  "main": ["./dist/qunit/blanket.js"]
-}


### PR DESCRIPTION
```
bower : bower blanket#*                        deprecated Package blanket is using the deprecated component.json
At line:3 char:1
+ bower install --no-color
+ ~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (bower blanket#*... component.json:String) [], RemoteException
    + FullyQualifiedErrorId : NativeCommandError
 
bower blanket#*                          mismatch Version declared in the json (1.1.5) is different than the resolved one (1.1.7)
 
bower blanket#*                      invalid-meta blanket is missing "ignore" entry in bower.json
 
```