### PR TITLE
Fix duplicate escaped '&' character

### DIFF
--- a/src/qunit/reporter.js
+++ b/src/qunit/reporter.js
@@ -44,8 +44,7 @@ blanket.defaultReporter = function(coverage){
             .replace(/\"/g, "&quot;")
             .replace(/\'/g, "&apos;")
             .replace(/`/g, "&grave;")
-            .replace(/[$]/g, "&dollar;")
-            .replace(/&/g, "&amp;");
+            .replace(/[$]/g, "&dollar;");
     }
 
     function isBranchFollowed(data,bool){


### PR DESCRIPTION
Fix the issue discussed in #547 as the last escape '&' will cause the previously escape results not working.
`grunt & npm test` pass all checks