### PR TITLE
docs: Fix a few typos

### DIFF
--- a/test/backbone-koans/js/ext/backbone.js
+++ b/test/backbone-koans/js/ext/backbone.js
@@ -274,7 +274,7 @@
     },
 
     // Fetch the model from the server. If the server's representation of the
-    // model differs from its current attributes, they will be overriden,
+    // model differs from its current attributes, they will be overridden,
     // triggering a `"change"` event.
     fetch : function(options) {
       options || (options = {});
@@ -885,7 +885,7 @@
   };
 
   // Element lookup, scoped to DOM elements within the current view.
-  // This should be prefered to global lookups, if you're dealing with
+  // This should be preferred to global lookups, if you're dealing with
   // a specific view.
   var selectorDelegate = function(selector) {
     return $(selector, this.el);
@@ -984,7 +984,7 @@
     // Ensure that the View has a DOM element to render into.
     // If `this.el` is a string, pass it through `$()`, take the first
     // matching element, and re-assign it to `el`. Otherwise, create
-    // an element from the `id`, `className` and `tagName` proeprties.
+    // an element from the `id`, `className` and `tagName` properties.
     _ensureElement : function() {
       if (!this.el) {
         var attrs = this.attributes || {};

--- a/test/backbone-koans/js/ext/jquery.js
+++ b/test/backbone-koans/js/ext/jquery.js
@@ -7318,7 +7318,7 @@ jQuery.extend({
 		// Apply prefilters
 		inspectPrefiltersOrTransports( prefilters, s, options, jqXHR );
 
-		// If request was aborted inside a prefiler, stop there
+		// If request was aborted inside a profiler, stop there
 		if ( state === 2 ) {
 			return false;
 		}

--- a/test/backbone-koans/js/ext/sinon-1.3.1.js
+++ b/test/backbone-koans/js/ext/sinon-1.3.1.js
@@ -2730,7 +2730,7 @@ if (typeof module == "object" && typeof require == "function") {
 /**
  * The Sinon "server" mimics a web server that receives requests from
  * sinon.FakeXMLHttpRequest and provides an API to respond to those requests,
- * both synchronously and asynchronously. To respond synchronuously, canned
+ * both synchronously and asynchronously. To respond synchronously, canned
  * answers have to be provided upfront.
  *
  * @author Christian Johansen (christian@cjohansen.no)

--- a/test/commonjs/commonjs_bundle.js
+++ b/test/commonjs/commonjs_bundle.js
@@ -485,7 +485,7 @@ function urlResolveObject(source, relative) {
     // Put this after the other two cases because it simplifies the booleans
     if (psychotic) {
       source.hostname = source.host = srcPath.shift();
-      //occationaly the auth can get stuck only in host
+      //occasionally the auth can get stuck only in host
       //this especialy happens in cases like
       //url.resolveObject('mailto:local1@domain1', 'local2@domain2')
       var authInHost = source.host && arrayIndexOf(source.host, '@') > 0 ?
@@ -565,7 +565,7 @@ function urlResolveObject(source, relative) {
   if (psychotic) {
     source.hostname = source.host = isAbsolute ? '' :
                                     srcPath.length ? srcPath.shift() : '';
-    //occationaly the auth can get stuck only in host
+    //occasionally the auth can get stuck only in host
     //this especialy happens in cases like
     //url.resolveObject('mailto:local1@domain1', 'local2@domain2')
     var authInHost = source.host && arrayIndexOf(source.host, '@') > 0 ?

--- a/test/jquery-usage/js/ext/backbone.js
+++ b/test/jquery-usage/js/ext/backbone.js
@@ -274,7 +274,7 @@
     },
 
     // Fetch the model from the server. If the server's representation of the
-    // model differs from its current attributes, they will be overriden,
+    // model differs from its current attributes, they will be overridden,
     // triggering a `"change"` event.
     fetch : function(options) {
       options || (options = {});
@@ -885,7 +885,7 @@
   };
 
   // Element lookup, scoped to DOM elements within the current view.
-  // This should be prefered to global lookups, if you're dealing with
+  // This should be preferred to global lookups, if you're dealing with
   // a specific view.
   var selectorDelegate = function(selector) {
     return $(selector, this.el);
@@ -984,7 +984,7 @@
     // Ensure that the View has a DOM element to render into.
     // If `this.el` is a string, pass it through `$()`, take the first
     // matching element, and re-assign it to `el`. Otherwise, create
-    // an element from the `id`, `className` and `tagName` proeprties.
+    // an element from the `id`, `className` and `tagName` properties.
     _ensureElement : function() {
       if (!this.el) {
         var attrs = this.attributes || {};

--- a/test/jquery-usage/js/ext/jquery.js
+++ b/test/jquery-usage/js/ext/jquery.js
@@ -7318,7 +7318,7 @@ jQuery.extend({
 		// Apply prefilters
 		inspectPrefiltersOrTransports( prefilters, s, options, jqXHR );
 
-		// If request was aborted inside a prefiler, stop there
+		// If request was aborted inside a profiler, stop there
 		if ( state === 2 ) {
 			return false;
 		}

--- a/test/jquery-usage/js/ext/sinon-1.3.1.js
+++ b/test/jquery-usage/js/ext/sinon-1.3.1.js
@@ -2730,7 +2730,7 @@ if (typeof module == "object" && typeof require == "function") {
 /**
  * The Sinon "server" mimics a web server that receives requests from
  * sinon.FakeXMLHttpRequest and provides an API to respond to those requests,
- * both synchronously and asynchronously. To respond synchronuously, canned
+ * both synchronously and asynchronously. To respond synchronously, canned
  * answers have to be provided upfront.
  *
  * @author Christian Johansen (christian@cjohansen.no)

--- a/test/usage/backbone.js
+++ b/test/usage/backbone.js
@@ -1012,7 +1012,7 @@
     tagName: 'div',
 
     // jQuery delegate for element lookup, scoped to DOM elements within the
-    // current view. This should be prefered to global lookups where possible.
+    // current view. This should be preferred to global lookups where possible.
     $: function(selector) {
       return this.$el.find(selector);
     },


### PR DESCRIPTION
There are small typos in:
- test/backbone-koans/js/ext/backbone.js
- test/backbone-koans/js/ext/jquery.js
- test/backbone-koans/js/ext/sinon-1.3.1.js
- test/commonjs/commonjs_bundle.js
- test/jquery-usage/js/ext/backbone.js
- test/jquery-usage/js/ext/jquery.js
- test/jquery-usage/js/ext/sinon-1.3.1.js
- test/usage/backbone.js

Fixes:
- Should read `preferred` rather than `prefered`.
- Should read `synchronously` rather than `synchronuously`.
- Should read `properties` rather than `proeprties`.
- Should read `profiler` rather than `prefiler`.
- Should read `overridden` rather than `overriden`.
- Should read `occasionally` rather than `occationaly`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md